### PR TITLE
Add new Pki::issue method that takes an IssueOptions object

### DIFF
--- a/src/main/java/com/bettercloud/vault/api/pki/IssueOptions.java
+++ b/src/main/java/com/bettercloud/vault/api/pki/IssueOptions.java
@@ -1,0 +1,96 @@
+package com.bettercloud.vault.api.pki;
+
+import java.util.List;
+
+/**
+ * Value class for options to be passed to the PKI issue API.
+ */
+public class IssueOptions {
+
+    private List<String> altNames;
+    private List<String> ipSans;
+    private List<String> uriSans;
+    private List<String> otherSans;
+    private String ttl;
+    private CredentialFormat credentialFormat;
+    private PrivateKeyFormat privateKeyFormat;
+    private Boolean excludeCnFromSans;
+    private String csr;
+
+    public IssueOptions altNames(List<String> altNames) {
+        this.altNames = altNames;
+        return this;
+    }
+
+    public IssueOptions ipSans(List<String> ipSans) {
+        this.ipSans = ipSans;
+        return this;
+    }
+
+    public IssueOptions uriSans(List<String> uriSans) {
+        this.uriSans = uriSans;
+        return this;
+    }
+
+    public IssueOptions otherSans(List<String> otherSans) {
+        this.otherSans = otherSans;
+        return this;
+    }
+
+    public IssueOptions ttl(String ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+
+    public IssueOptions credentialFormat(CredentialFormat format) {
+        this.credentialFormat = format;
+        return this;
+    }
+
+    public IssueOptions privateKeyFormat(PrivateKeyFormat privateKeyFormat) {
+        this.privateKeyFormat = privateKeyFormat;
+        return this;
+    }
+
+    public IssueOptions excludeCnFromSans(Boolean excludeCnFromSans) {
+        this.excludeCnFromSans = excludeCnFromSans;
+        return this;
+    }
+
+    public IssueOptions csr(String csr) {
+        this.csr = csr;
+        return this;
+    }
+
+    public List<String> getAltNames() {
+        return altNames;
+    }
+
+    public List<String> getIpSans() { return ipSans; }
+
+    public List<String> getUriSans() {
+        return uriSans;
+    }
+
+    public List<String> getOtherSans() {
+        return otherSans;
+    }
+
+    public String getTtl() {
+        return ttl;
+    }
+
+    public CredentialFormat getCredentialFormat() { return credentialFormat; }
+
+    public PrivateKeyFormat getPrivateKeyFormat() {
+        return privateKeyFormat;
+    }
+
+    public Boolean isExcludeCnFromSans() {
+        return excludeCnFromSans;
+    }
+
+    public String getCsr() {
+        return csr;
+    }
+}

--- a/src/main/java/com/bettercloud/vault/api/pki/PrivateKeyFormat.java
+++ b/src/main/java/com/bettercloud/vault/api/pki/PrivateKeyFormat.java
@@ -1,0 +1,24 @@
+package com.bettercloud.vault.api.pki;
+
+/**
+ * <p>Possible format options for private keys issued by the PKI backend.</p>
+ */
+public enum PrivateKeyFormat {
+    DER,
+    PEM,
+    PKCS8;
+
+    public static PrivateKeyFormat fromString(final String text) {
+        if (text != null) {
+            for (final PrivateKeyFormat format : PrivateKeyFormat.values()) {
+                if (text.equalsIgnoreCase(format.toString())) {
+                    return format;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() { return super.toString().toLowerCase(); }
+}

--- a/src/test-integration/java/com/bettercloud/vault/api/AuthBackendTokenTests.java
+++ b/src/test-integration/java/com/bettercloud/vault/api/AuthBackendTokenTests.java
@@ -9,7 +9,6 @@ import com.bettercloud.vault.util.VaultContainer;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;

--- a/src/test/java/com/bettercloud/vault/vault/api/TransitApiTest.java
+++ b/src/test/java/com/bettercloud/vault/vault/api/TransitApiTest.java
@@ -7,13 +7,11 @@ import com.bettercloud.vault.json.JsonObject;
 import com.bettercloud.vault.response.LogicalResponse;
 import com.bettercloud.vault.vault.VaultTestUtils;
 import com.bettercloud.vault.vault.mock.MockVault;
-import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.util.Collections;
 import java.util.Optional;
+import org.eclipse.jetty.server.Server;
+import org.junit.After;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
To avoid a breaking api change, duplicated the existing Pki::issue
method and updated it to take an IssueOptions object. This makes the
api more flexible for future api option value additions and stacking
many positional arguments into the method signature.